### PR TITLE
Add Bookworm Signature to sysroot

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,8 +47,11 @@ build_sysroot()
     rm -rf "${SYSROOT}"
     mkdir -p "${SYSROOT}/etc/apt/trusted.gpg.d"
     rm -rf "${SYSROOT}/etc/apt/trusted.gpg.d/debian-keyring.gpg"
+    # shellcheck disable=SC2129
     curl https://ftp-master.debian.org/keys/archive-key-11.asc | gpg --dearmor >> "${SYSROOT}/etc/apt/trusted.gpg.d/debian-keyring.gpg"
     curl https://ftp-master.debian.org/keys/release-11.asc | gpg --dearmor >> "${SYSROOT}/etc/apt/trusted.gpg.d/debian-keyring.gpg"
+    curl https://ftp-master.debian.org/keys/archive-key-12.asc | gpg --dearmor >> "${SYSROOT}/etc/apt/trusted.gpg.d/debian-keyring.gpg"
+    curl https://ftp-master.debian.org/keys/release-12.asc | gpg --dearmor >> "${SYSROOT}/etc/apt/trusted.gpg.d/debian-keyring.gpg"
 
     multistrap -f "${TOOLS_DIR}/sysroot_multistrap.cfg" -d "${SYSROOT}"
 

--- a/docker_env/buildenv_check.sh
+++ b/docker_env/buildenv_check.sh
@@ -108,4 +108,3 @@ fi
 echo "Build environment OK"
 echo_line
 
-exit 0


### PR DESCRIPTION
The signature for Debian Bookworm repository is missing. This commit adds it so we can build the sysroot.